### PR TITLE
Fix freezing sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,19 @@ A valid configuration may look like [this](examples/zones.yaml) or this:
               x: 6m
               y: 0m
 ```
+
+## Troubleshooting
+
+When using Dupont connectors make sure they make proper contact. The very short pins on the LD2450 Sensor can easily go loose or break.
+
+I recommend using a `5V` power supply and the `5V` input pin whenever possible.
+Using the the `3.3V` pin on the LD2450 sensor may cause instabilities during operation depending on the power supply, voltage regulator and other components used on the same power circuit.
+In a test scenario using a `3.3V` voltage regulator, an ESP-01 and a DHT22 the LD2450 sensor was not able to provide measurements. Observing the LD2450's TX pin using an oscilloscope yielded no updates and noisy behavior around `3.3V`. Switching to `5V` on the LD2450 sensor resolved this issue and consistent updates from the sensor were observed.
+In a different scenario, when using `3.3V` provided by an ESP32 development board, sensor updates arrived inconsistently/went missing.
+
+In some configurations, this LD2450 component may not perform ideally. If this component is used in combination with other components on a single ESP, especially ones that require long processing times, some updates provided by the sensor may be missed. As a symptom (zone) count sensors may report as `Unknown` for short periods of time and switches become unresponsive.
+If this is the case try the following steps:
+
+- increase `rx_buffer_size`
+- use a minimal ESPHome yaml configuration for troubleshooting
+- use a reliable `5V` power source for the sensor

--- a/components/LD2450/LD2450.cpp
+++ b/components/LD2450/LD2450.cpp
@@ -135,88 +135,124 @@ namespace esphome::ld2450
             command_send_retries_ = 0;
         }
 
-        // Skip stream until start of message and parse header
-        if (!peek_status_ && available() >= 4)
+        // Try to process as many messages as possible in a single iteration
+        bool processed_message = false;
+        do
         {
-            // Try to read the header and abort on mismatch
-            const uint8_t *header;
-            bool skip = false;
-            uint8_t message_type;
-            uint8_t first_byte = read();
-            if (first_byte == update_header[0])
+            processed_message = false;
+
+            // Skip stream until start of message and parse header
+            while (!peek_status_ && available() >= 4)
             {
-                header = update_header;
-                message_type = 1;
-            }
-            else if (first_byte == config_header[0])
-            {
-                header = config_header;
-                message_type = 2;
-            }
-            else
-            {
-                skip = true;
-            }
-
-            for (int i = 1; i < 4 && !skip; i++)
-            {
-                if (read() != header[i])
-                    skip = true;
-            }
-
-            if (!skip)
-                // Flag successful header reading
-                peek_status_ = message_type;
-        }
-
-        if (peek_status_ == 1 && available() >= 28)
-        {
-            uint8_t msg[26] = {0x00};
-            read_array(msg, 26);
-            peek_status_ = 0;
-
-            // Skip invalid messages
-            if (msg[24] != 0x55 || msg[25] != 0xCC)
-                return;
-
-            process_message(msg, 24);
-        }
-        if (peek_status_ == 2 && (available() >= 2 || configuration_message_length_ > 0))
-        {
-            if (configuration_message_length_ == 0)
-            {
-                // Read message content length
-                uint8_t content_length[2];
-                read_array(content_length, 2);
-                configuration_message_length_ = content_length[1] << 8 | content_length[0];
-            }
-
-            // Wait until message and frame end are available
-            if (available() >= configuration_message_length_ + 4)
-            {
-                uint8_t msg[configuration_message_length_ + 4] = {0x00};
-                read_array(msg, configuration_message_length_ + 4);
-
-                // Assert frame end read correctly
-                if (msg[configuration_message_length_] == 0x04 && msg[configuration_message_length_ + 1] == 0x03 && msg[configuration_message_length_ + 2] == 0x02 && msg[configuration_message_length_ + 3] == 0x01)
+                // Try to read the header and abort on mismatch
+                const uint8_t *header;
+                bool skip = false;
+                uint8_t message_type;
+                uint8_t first_byte = read();
+                if (first_byte == update_header[0])
                 {
-                    process_config_message(msg, configuration_message_length_);
+                    header = update_header;
+                    message_type = 1;
                 }
-                configuration_message_length_ = 0;
-                peek_status_ = 0;
-            }
-        }
+                else if (first_byte == config_header[0])
+                {
+                    header = config_header;
+                    message_type = 2;
+                }
+                else
+                {
+                    skip = true;
+                }
 
+                for (int i = 1; i < 4 && !skip; i++)
+                {
+                    if (read() != header[i])
+                        skip = true;
+                }
+
+                if (!skip)
+                    // Flag successful header reading
+                    peek_status_ = message_type;
+            }
+
+            if (peek_status_ == 1 && available() >= 26)
+            {
+                uint8_t msg[26] = {0x00};
+                read_array(msg, 26);
+                peek_status_ = 0;
+
+                // Skip invalid messages
+                if (msg[24] != 0x55 || msg[25] != 0xCC)
+                    return;
+
+                process_message(msg, 24);
+                processed_message = true;
+            }
+            if (peek_status_ == 2 && (available() >= 2 || configuration_message_length_ > 0))
+            {
+                if (configuration_message_length_ == 0)
+                {
+                    // Read message content length
+                    uint8_t content_length[2];
+                    read_array(content_length, 2);
+                    configuration_message_length_ = content_length[1] << 8 | content_length[0];
+                    // Limit max message length
+                    configuration_message_length_ = std::min(configuration_message_length_, 20);
+                }
+
+                // Wait until message and frame end are available
+                if (available() >= configuration_message_length_ + 4)
+                {
+                    uint8_t msg[configuration_message_length_ + 4] = {0x00};
+                    read_array(msg, configuration_message_length_ + 4);
+
+                    // Assert frame end read correctly
+                    if (msg[configuration_message_length_] == 0x04 && msg[configuration_message_length_ + 1] == 0x03 && msg[configuration_message_length_ + 2] == 0x02 && msg[configuration_message_length_ + 3] == 0x01)
+                    {
+                        process_config_message(msg, configuration_message_length_);
+                    }
+                    configuration_message_length_ = 0;
+                    peek_status_ = 0;
+                    processed_message = true;
+                }
+            }
+
+        } while (processed_message);
+
+        // Detect missing updates from the sensor (not connect or in configuration mode)
         if (sensor_available_ && millis() - last_message_received_ > SENSOR_UNAVAILABLE_TIMEOUT)
         {
             sensor_available_ = false;
 
             ESP_LOGE(TAG, "LD2450-Sensor stopped sending updates!");
 
-            // Update zones and related components
+            // Update zones and related components (unavailable)
             for (Zone *zone : zones_)
             {
                 zone->update(targets_, sensor_available_);
+            }
+
+            // Update targets and related components (unavailable)
+            for (Target *target : targets_)
+            {
+                target->clear();
+            }
+        }
+
+        if (available() != last_available_size_)
+        {
+            last_available_size_ = available();
+            last_available_change_ = millis();
+        }
+
+        // Assume the rx buffer has overflowed in the past and is unable to recover - read everything available
+        if (available() != 0 && millis() - last_available_change_ > SENSOR_UNAVAILABLE_TIMEOUT / 2)
+        {
+            // Clear out rx buffer
+            ESP_LOGD(TAG, "Clearing RX buffer.");
+            while (available())
+            {
+                read();
             }
         }
     }
@@ -225,6 +261,8 @@ namespace esphome::ld2450
     {
         sensor_available_ = true;
         last_message_received_ = millis();
+        configuration_mode_ = false;
+
         for (int i = 0; i < 3; i++)
         {
             int offset = 8 * i;

--- a/components/LD2450/LD2450.h
+++ b/components/LD2450/LD2450.h
@@ -23,6 +23,7 @@
 
 #define SENSOR_UNAVAILABLE_TIMEOUT 4000
 #define CONFIG_RECOVERY_INTERVAL 60000
+#define POST_RESTART_LOCKOUT_DELAY 2000
 
 #define COMMAND_MAX_RETRIES 10
 #define COMMAND_RETRY_DELAY 100
@@ -344,6 +345,9 @@ namespace esphome::ld2450
 
         /// @brief timestamp of the last attempt to leave config mode if it's not responding
         uint32_t last_config_leave_attempt_ = 0;
+
+        /// @brief timestamp of lockout period after applying changes requiring a restart
+        uint32_t apply_change_lockout_ = 0;
 
         /// @brief nr of available bytes during the last iteration
         int last_available_size_ = 0;

--- a/components/LD2450/LD2450.h
+++ b/components/LD2450/LD2450.h
@@ -21,7 +21,7 @@
 #include "esphome/components/button/button.h"
 #endif
 
-#define SENSOR_UNAVAILABLE_TIMEOUT 1000
+#define SENSOR_UNAVAILABLE_TIMEOUT 4000
 
 #define COMMAND_MAX_RETRIES 10
 #define COMMAND_RETRY_DELAY 100
@@ -337,6 +337,12 @@ namespace esphome::ld2450
 
         /// @brief timestamp of the last received message
         uint32_t last_message_received_ = 0;
+
+        /// @brief timestamp at which the last available size change has occurred. Once the rx buffer has overflown it must be cleared manually on some configurations to receive new data
+        uint32_t last_available_change_ = 0;
+
+        /// @brief nr of available bytes during the last iteration
+        int last_available_size_ = 0;
 
         /// @brief Queue of commands to execute
         std::vector<std::vector<uint8_t>> command_queue_;

--- a/components/LD2450/LD2450.h
+++ b/components/LD2450/LD2450.h
@@ -22,6 +22,7 @@
 #endif
 
 #define SENSOR_UNAVAILABLE_TIMEOUT 4000
+#define CONFIG_RECOVERY_INTERVAL 60000
 
 #define COMMAND_MAX_RETRIES 10
 #define COMMAND_RETRY_DELAY 100
@@ -340,6 +341,9 @@ namespace esphome::ld2450
 
         /// @brief timestamp at which the last available size change has occurred. Once the rx buffer has overflown it must be cleared manually on some configurations to receive new data
         uint32_t last_available_change_ = 0;
+
+        /// @brief timestamp of the last attempt to leave config mode if it's not responding
+        uint32_t last_config_leave_attempt_ = 0;
 
         /// @brief nr of available bytes during the last iteration
         int last_available_size_ = 0;

--- a/components/LD2450/target.cpp
+++ b/components/LD2450/target.cpp
@@ -26,7 +26,8 @@ namespace esphome::ld2450
     {
         if (debug_)
         {
-            if (millis() - last_debug_message_ > DEBUG_FREQUENCY)
+            // Only show debug messages if updates are available
+            if (is_present() && millis() - last_debug_message_ > DEBUG_FREQUENCY)
             {
                 last_debug_message_ = millis();
                 std::string name = name_ != nullptr ? name_ : "Unnamed Target";


### PR DESCRIPTION
This PR fixes an issue related to message processing. When using complex ESPHome configurations and configurations using components that require a delay/long processing time, the RX buffer may fill up.
This happens because its content is not processed in time.
Once this happens, new updates from the sensor are not processed properly and new data does not arrive.
This change also affects the reliability of switch components (reading their state), as the response messages might have been lost due to the RX buffer overflowing.

Increasing the RX buffer size using `rx_buffer_size` can be helpful. The changes introduced in this PR ensure the buffer is always read as far as possible.  

Try this PR using:
```yaml
external_components:
  - source: github://TillFleisch/ESPHome-HLK-LD2450@buffer-read-fix
    refresh: 30min
```

Close #1 
Close #5 