### PR TITLE
Fix sensor filter compatibility

### DIFF
--- a/components/LD2450/LD2450.cpp
+++ b/components/LD2450/LD2450.cpp
@@ -305,8 +305,6 @@ namespace esphome::ld2450
             // Flip x axis if required
             x = x * (flip_x_axis_ ? -1 : 1);
 
-            targets_[i]->update_values(x, y, speed, distance_resolution);
-
             // Filter targets further than max detection distance and max angle
             float angle = -(atan2(y, x) * (180 / M_PI) - 90);
             if ((y <= max_detection_distance_ || (targets_[i]->is_present() && y <= max_detection_distance_ + max_distance_margin_)) &&

--- a/components/LD2450/LD2450.cpp
+++ b/components/LD2450/LD2450.cpp
@@ -238,6 +238,15 @@ namespace esphome::ld2450
 
             ESP_LOGE(TAG, "LD2450-Sensor stopped sending updates!");
 
+#ifdef USE_BINARY_SENSOR
+            if (occupancy_binary_sensor_ != nullptr)
+                occupancy_binary_sensor_->publish_state(false);
+#endif
+#ifdef USE_SENSOR
+            if (target_count_sensor_ != nullptr)
+                target_count_sensor_->publish_state(NAN);
+#endif
+
             // Update zones and related components (unavailable)
             for (Zone *zone : zones_)
             {
@@ -329,11 +338,11 @@ namespace esphome::ld2450
         is_occupied_ = target_count > 0;
 
 #ifdef USE_BINARY_SENSOR
-        if (occupancy_binary_sensor_ != nullptr && occupancy_binary_sensor_->state != is_occupied_)
+        if (occupancy_binary_sensor_ != nullptr)
             occupancy_binary_sensor_->publish_state(is_occupied_);
 #endif
 #ifdef USE_SENSOR
-        if (target_count_sensor_ != nullptr && target_count_sensor_->state != target_count)
+        if (target_count_sensor_ != nullptr && target_count_sensor_->raw_state != target_count)
             target_count_sensor_->publish_state(target_count);
 #endif
 

--- a/components/LD2450/LD2450.h
+++ b/components/LD2450/LD2450.h
@@ -11,7 +11,7 @@
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
-#ifdef USE_BINARY_SENSOR
+#ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
 #endif
 #ifdef USE_NUMBER

--- a/components/LD2450/zone.cpp
+++ b/components/LD2450/zone.cpp
@@ -81,11 +81,11 @@ namespace esphome::ld2450
         }
 
 #ifdef USE_BINARY_SENSOR
-        if (occupancy_binary_sensor_ != nullptr && (occupancy_binary_sensor_->state != (target_count > 0) || !occupancy_binary_sensor_->has_state()))
+        if (occupancy_binary_sensor_ != nullptr)
             occupancy_binary_sensor_->publish_state(target_count > 0);
 #endif
 #ifdef USE_SENSOR
-        if (target_count_sensor_ != nullptr && (target_count_sensor_->state != target_count || !target_count_sensor_->has_state()))
+        if (target_count_sensor_ != nullptr && (target_count_sensor_->raw_state != target_count))
             target_count_sensor_->publish_state(target_count);
 #endif
     }


### PR DESCRIPTION
This PR fixes some compatibility issues with filters which are applied to sensors.

Try this PR using:

```yaml
external_components:
  - source: github://TillFleisch/ESPHome-HLK-LD2450@fix_sensor_filters
    refresh: 30min
```

Close #24 