### PR TITLE
fix(LD2450): Replace deprecated raw_state access with getter methods

### DIFF
--- a/components/LD2450/LD2450.cpp
+++ b/components/LD2450/LD2450.cpp
@@ -345,7 +345,7 @@ namespace esphome::ld2450
             occupancy_binary_sensor_->publish_state(is_occupied_);
 #endif
 #ifdef USE_SENSOR
-        if (target_count_sensor_ != nullptr && target_count_sensor_->raw_state != target_count)
+        if (target_count_sensor_ != nullptr && target_count_sensor_->get_raw_state() != target_count)
             target_count_sensor_->publish_state(target_count);
 #endif
 

--- a/components/LD2450/polling_sensor.h
+++ b/components/LD2450/polling_sensor.h
@@ -15,18 +15,19 @@ namespace esphome::ld2450
         void setup() override
         {
             // Determine unit conversion
-            if (unit_of_measurement_ != nullptr)
+            const auto &uom = get_unit_of_measurement_ref();
+            if (!uom.empty())
             {
-                if (strcmp(unit_of_measurement_, "m") == 0)
+                if (uom == "m")
                     conversion_factor_ = 0.001f;
-                else if ((strcmp(unit_of_measurement_, "cm") == 0))
+                else if (uom == "cm")
                     conversion_factor_ = 0.1f;
             }
         }
 
         void update() override
         {
-            if (raw_state != value_ && !(std::isnan(raw_state) && std::isnan(value_)))
+            if (get_raw_state() != value_ && !(std::isnan(get_raw_state()) && std::isnan(value_)))
                 publish_state(value_);
         }
 

--- a/components/LD2450/zone.cpp
+++ b/components/LD2450/zone.cpp
@@ -85,7 +85,7 @@ namespace esphome::ld2450
             occupancy_binary_sensor_->publish_state(target_count > 0);
 #endif
 #ifdef USE_SENSOR
-        if (target_count_sensor_ != nullptr && (target_count_sensor_->raw_state != target_count))
+        if (target_count_sensor_ != nullptr && (target_count_sensor_->get_raw_state() != target_count))
             target_count_sensor_->publish_state(target_count);
 #endif
     }

--- a/components/LD2450/zone.h
+++ b/components/LD2450/zone.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <map>
 #include "target.h"
+#include "esphome/core/automation.h"
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml


### PR DESCRIPTION
fix(LD2450): Fix compilation errors with ESPHome 2026.4+

### Summary
Fixes compilation failures caused by API changes in recent ESPHome versions.

### Changes
- **polling_sensor.h**: Replace removed `unit_of_measurement_` direct member
  access with `get_unit_of_measurement_ref()` (non-deprecated const reference
  getter)
- **polling_sensor.h**: Replace deprecated `raw_state` with `get_raw_state()`
- **LD2450.cpp**: Replace deprecated `target_count_sensor_->raw_state` with
  `target_count_sensor_->get_raw_state()`
- **zone.cpp**: Same `raw_state` → `get_raw_state()` fix for zone target count
- **zone.h**: Add missing `#include "esphome/core/automation.h"` required for
  `Action<Ts...>` base class

### Testing
- Compiled successfully against ESPHome 2026.4.3 using `tests/full.yaml`