### PR TITLE
Fix compilation against ESPHome 2026.5.3

### DIFF
--- a/components/LD2450/LD2450.cpp
+++ b/components/LD2450/LD2450.cpp
@@ -345,7 +345,7 @@ namespace esphome::ld2450
             occupancy_binary_sensor_->publish_state(is_occupied_);
 #endif
 #ifdef USE_SENSOR
-        if (target_count_sensor_ != nullptr && target_count_sensor_->raw_state != target_count)
+        if (target_count_sensor_ != nullptr && target_count_sensor_->get_raw_state() != target_count)
             target_count_sensor_->publish_state(target_count);
 #endif
 

--- a/components/LD2450/__init__.py
+++ b/components/LD2450/__init__.py
@@ -727,6 +727,7 @@ def zone_to_code(config):
             cv.Required(CONF_POLYGON): cv.templatable(cv.ensure_list(Point)),
         }
     ),
+    synchronous=True,
 )
 async def update_polygon_to_code(config, action_id, template_arg, args):
     """Code generation for the update (template) polygon action."""

--- a/components/LD2450/polling_sensor.h
+++ b/components/LD2450/polling_sensor.h
@@ -15,18 +15,17 @@ namespace esphome::ld2450
         void setup() override
         {
             // Determine unit conversion
-            if (unit_of_measurement_ != nullptr)
-            {
-                if (strcmp(unit_of_measurement_, "m") == 0)
-                    conversion_factor_ = 0.001f;
-                else if ((strcmp(unit_of_measurement_, "cm") == 0))
-                    conversion_factor_ = 0.1f;
-            }
+            const StringRef unit = this->get_unit_of_measurement_ref();
+            if (unit == "m")
+                conversion_factor_ = 0.001f;
+            else if (unit == "cm")
+                conversion_factor_ = 0.1f;
         }
 
         void update() override
         {
-            if (raw_state != value_ && !(std::isnan(raw_state) && std::isnan(value_)))
+            const float current = this->get_raw_state();
+            if (current != value_ && !(std::isnan(current) && std::isnan(value_)))
                 publish_state(value_);
         }
 

--- a/components/LD2450/zone.cpp
+++ b/components/LD2450/zone.cpp
@@ -85,7 +85,7 @@ namespace esphome::ld2450
             occupancy_binary_sensor_->publish_state(target_count > 0);
 #endif
 #ifdef USE_SENSOR
-        if (target_count_sensor_ != nullptr && (target_count_sensor_->raw_state != target_count))
+        if (target_count_sensor_ != nullptr && (target_count_sensor_->get_raw_state() != target_count))
             target_count_sensor_->publish_state(target_count);
 #endif
     }

--- a/components/LD2450/zone.h
+++ b/components/LD2450/zone.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <map>
+#include "esphome/core/automation.h"
 #include "target.h"
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"


### PR DESCRIPTION
Changes made by AI as I am not C++ savy enough.

ESPHome 2026.x tightened several public APIs this component relied on:

* sensor::Sensor::unit_of_measurement_ was removed; switch to get_unit_of_measurement_ref() and compare via StringRef.
* sensor::Sensor::raw_state is deprecated (will be removed in 2026.10.0); use get_raw_state().
* esphome::Action<Ts...> and TEMPLATABLE_VALUE are no longer pulled in by transitive includes; add an explicit #include "esphome/core/automation.h" in zone.h.
* automation.register_action() now requires a keyword-only synchronous= argument; pass synchronous=True because UpdatePolygonAction::play() runs synchronously.

 Verified by esphome compile tests/full.yaml against ESPHome 2026.5.3 (esp-idf): 0 errors, 0 deprecation warnings.
